### PR TITLE
Run unit tests on Julia v1.11

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -37,7 +37,7 @@ jobs:
       matrix:
         version:
           - 'min' # Earliest julia version according to `Project.toml`
-          - '1'
+          - '1.11'
         os:
           - ubuntu-latest
         arch:


### PR DESCRIPTION
Julia v1.12 has been released yesterday night, but Enzyme isn't fully compatible with this version yet. Ref https://github.com/UCL/Supergrassi.jl/pull/102#issuecomment-3379628727.